### PR TITLE
MenuCtrl: use system menu bar on OSX

### DIFF
--- a/src/main/java/gndata/app/ui/main/MenuCtrl.java
+++ b/src/main/java/gndata/app/ui/main/MenuCtrl.java
@@ -50,6 +50,9 @@ public class MenuCtrl implements Initializable {
     public void initialize(URL url, ResourceBundle resourceBundle) {
         // set a listener that hides or shows the project menu depending on the state
         this.projectState.addListener((obs, o, n) -> projectMenu.setVisible(n != null));
+        
+        //use osx system menu
+        menu.setUseSystemMenuBar(true);
     }
 
     /**


### PR DESCRIPTION
Otherwise the menu is embedded in the window,
which looks super off in OSX.
