### PR TITLE
Config: absolute paths in project config file

### DIFF
--- a/src/main/java/gndata/lib/config/AbstractConfig.java
+++ b/src/main/java/gndata/lib/config/AbstractConfig.java
@@ -14,6 +14,7 @@ import java.nio.file.*;
 import static com.fasterxml.jackson.databind.DeserializationFeature.*;
 import static com.fasterxml.jackson.databind.SerializationFeature.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -44,6 +45,7 @@ public abstract class AbstractConfig {
      *
      * @return The path to the configuration file.
      */
+    @JsonIgnore
     public String getFilePath() {
         return filePath;
     }
@@ -96,7 +98,10 @@ public abstract class AbstractConfig {
                 .disable(FAIL_ON_UNKNOWN_PROPERTIES);
 
         try {
-            return mapper.readValue(tmpPath.toFile(), cls);
+            T config = mapper.readValue(tmpPath.toFile(), cls);
+            config.setFilePath(tmpPath.toString());
+
+            return config;
         } catch (IOException e) {
             throw new IOException("Unable to read configuration file: " + filePath, e);
         }

--- a/src/main/java/gndata/lib/config/ProjectConfig.java
+++ b/src/main/java/gndata/lib/config/ProjectConfig.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.nio.file.*;
 import javafx.beans.property.SimpleStringProperty;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Project configuration;
  */
@@ -40,6 +42,7 @@ public class ProjectConfig extends AbstractConfig {
         description.set(other.getDescription());
     }
 
+    @JsonIgnore
     public String getProjectPath() {
         return projectPath.get();
     }
@@ -93,7 +96,10 @@ public class ProjectConfig extends AbstractConfig {
         Path filePath = absPath.resolve(IN_PROJECT_PATH);
 
         if (Files.exists(filePath)) {
-            return AbstractConfig.load(filePath.toString(), ProjectConfig.class);
+            ProjectConfig config = AbstractConfig.load(filePath.toString(), ProjectConfig.class);
+            config.setProjectPath(absPath.toString());
+
+            return config;
         } else {
             ProjectConfig config = new ProjectConfig();
             // set defaults here if necessary


### PR DESCRIPTION
This fixes #43 by removing the file paths from the system and project config files.

For old config files it might be necessary to delete the paths manually in some cases.
