### PR TITLE
Query: use SELECT instead of CONSTRUCT + small layout changes

### DIFF
--- a/src/main/java/gndata/app/ui/query/QueryView.fxml
+++ b/src/main/java/gndata/app/ui/query/QueryView.fxml
@@ -52,10 +52,10 @@ LICENSE file in the root of the Project.
         <SplitPane orientation="HORIZONTAL">
 
             <VBox prefWidth="374.0">
-                <TextArea fx:id="prefixArea" editable="false"/>
+                <TextArea fx:id="prefixArea" editable="false" prefHeight="100.0" minHeight="100.0"/>
                 <fx:include source="builder/QueryPaneView.fxml"/>
                 <fx:include source="ListPaneView.fxml"/>
-                <TextArea fx:id="ta" editable="false"/>
+                <TextArea fx:id="ta" editable="false" prefHeight="100.0" minHeight="100.0"/>
             </VBox>
 
             <fx:include source="details/QueryDetailsView.fxml"/>

--- a/src/main/java/gndata/app/ui/query/builder/QueryPaneCtrl.java
+++ b/src/main/java/gndata/app/ui/query/builder/QueryPaneCtrl.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 
 import com.google.inject.Inject;
 import gndata.lib.srv.ResourceEvent;
+
+import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -35,6 +37,9 @@ public class QueryPaneCtrl implements Initializable {
     @FXML
     private ListView<QueryRow> lv;
 
+    @FXML
+    private VBox vbox;
+
     private ObservableList<QueryRow> queryRows;
     private QueryState qs;
 
@@ -50,6 +55,12 @@ public class QueryPaneCtrl implements Initializable {
         lv.setItems(queryRows);
 
         queryRows.add(new QueryRow("?x", "?y", "?z"));
+
+        Integer LIST_CELL_HEIGHT = 35;
+
+        lv.minHeightProperty().bind(Bindings.size(lv.getItems()).multiply(LIST_CELL_HEIGHT));
+        vbox.minHeightProperty().bind(lv.minHeightProperty().add(LIST_CELL_HEIGHT));
+        vbox.prefHeightProperty().bind(vbox.minHeightProperty());
     }
 
     public void addRow() {

--- a/src/main/java/gndata/app/ui/query/builder/QueryPaneCtrl.java
+++ b/src/main/java/gndata/app/ui/query/builder/QueryPaneCtrl.java
@@ -54,7 +54,7 @@ public class QueryPaneCtrl implements Initializable {
     public void initialize(URL url, ResourceBundle resourceBundle) {
         lv.setItems(queryRows);
 
-        queryRows.add(new QueryRow("?x", "?y", "?z"));
+        queryRows.add(new QueryRow("?x", "rdf:type", "thomas:AnalogSignal"));
 
         Integer LIST_CELL_HEIGHT = 35;
 
@@ -106,10 +106,9 @@ public class QueryPaneCtrl implements Initializable {
                 .collect(Collectors.toList());
 
         return StrUtils.strjoinNL(
-                "CONSTRUCT {",
-                String.join(" ", selectors),
-                "} WHERE { ",
-                String.join(" . ", conditions),
+                "SELECT " + String.join(" ", selectors),
+                "WHERE { ",
+                String.join(" .\n", conditions) + ".",
                 "}"
         );
     }

--- a/src/main/java/gndata/app/ui/query/builder/QueryPaneView.fxml
+++ b/src/main/java/gndata/app/ui/query/builder/QueryPaneView.fxml
@@ -15,6 +15,7 @@ LICENSE file in the root of the Project.
 <?import javafx.scene.layout.*?>
 <VBox xmlns:fx="http://javafx.com/fxml/1"
             xmlns="http://javafx.com/javafx/8"
+            fx:id="vbox"
             fx:controller="gndata.app.ui.query.builder.QueryPaneCtrl">
 
 
@@ -22,7 +23,7 @@ LICENSE file in the root of the Project.
 
     <!-- query rows go to the center -->
 
-    <ListView fx:id="lv" VBox.vgrow="ALWAYS" prefHeight="150"/>
+    <ListView fx:id="lv" VBox.vgrow="ALWAYS"/>
 
     <!-- buttons go to the bottom -->
 

--- a/src/main/java/gndata/app/ui/query/builder/QueryRowView.fxml
+++ b/src/main/java/gndata/app/ui/query/builder/QueryRowView.fxml
@@ -17,7 +17,6 @@ LICENSE file in the root of the Project.
 
 <HBox xmlns:fx="http://javafx.com/fxml/1"
       xmlns="http://javafx.com/javafx/8"
-      prefHeight="35.0"
       BorderPane.alignment="CENTER">
 
     <TextField fx:id="subject">""</TextField>

--- a/src/main/java/gndata/lib/srv/MetadataService.java
+++ b/src/main/java/gndata/lib/srv/MetadataService.java
@@ -43,6 +43,21 @@ public class MetadataService {
     }
 
     /**
+     * Provides a string with available PREFIX'es. May be used to build queries
+     * against current service.
+     *
+     * @return  String with prefixes
+     */
+    public String getPrefixHeader() {
+        return StrUtils.strjoinNL(getAnnotations()
+                    .getNsPrefixMap()
+                    .entrySet()
+                    .stream()
+                    .map(a -> "PREFIX " + a.getKey() + ": " + "<" + a.getValue() + ">")
+                    .collect(Collectors.toList()));
+    }
+
+    /**
      * Returns a Ontology RDF Model instance to access default and
      * custom ontology terms.
      *
@@ -160,11 +175,11 @@ public class MetadataService {
                 .collect(Collectors.toList());
     }
 
-    public Model SELECT(String queryString) {
+    public ResultSet SELECT(String queryString) {
         Query query = QueryFactory.create(queryString);
         QueryExecution qexec = QueryExecutionFactory.create(query, getAnnotations());
 
-        Model resultModel = ResultSetFormatter.toModel(qexec.execSelect());
+        ResultSet resultModel = ResultSetFactory.copyResults(qexec.execSelect());
         qexec.close();
 
         return resultModel;

--- a/src/main/java/gndata/lib/srv/ResourceEvent.java
+++ b/src/main/java/gndata/lib/srv/ResourceEvent.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Random;
 
 import com.hp.hpl.jena.rdf.model.Resource;
+import gndata.lib.util.Resources;
 
 
 public class ResourceEvent implements EventAdapter {
@@ -20,8 +21,8 @@ public class ResourceEvent implements EventAdapter {
 
         Random generator = new Random();
         Integer day_of_month = LocalDateTime.now().getDayOfMonth() - 2 + generator.nextInt(6);
-        Integer start_hour = generator.nextInt(5) + 8;
-        Integer end_hour = generator.nextInt(7) + start_hour;
+        Integer start_hour = generator.nextInt(5) + 4;
+        Integer end_hour = generator.nextInt(12) + start_hour;
 
         start = LocalDateTime.now();
         start = start.withDayOfMonth(day_of_month);
@@ -41,8 +42,11 @@ public class ResourceEvent implements EventAdapter {
     }
 
     public String getSummary() {
-        //return Resources.toNameString(res);
-        return res.getLocalName();
+        String name = Resources.toNameString(res);
+
+        return name.length() < 8 ? name : name.substring(0, 7);
+
+        //return res.getLocalName();
     }
 
     public String getDescription() {


### PR DESCRIPTION
Not everything is final, layout changes are intermediate