### PR TITLE
ensure TravisCI java version > 8u31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ branches:
   only:
   - master
 
-jdk:
-  - oraclejdk8
-
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install --only-upgrade -y oracle-java8-installer
+
+jdk:
+  - oraclejdk8
 
 after_success:
   - mvn clean test jacoco:report coveralls:jacoco

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ branches:
 
 jdk:
   - oraclejdk8
-  
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install --only-upgrade -y oracle-java8-installer
+
 after_success:
   - mvn clean test jacoco:report coveralls:jacoco
 


### PR DESCRIPTION
TravisCI is using java version 1.8.0_31. This version is missing some javafx components like TextFormatter.
This update should force TravisCI to use the lates java 8 version.